### PR TITLE
feat: Add PDF support and chromadb to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@
 google-generativeai
 beautifulsoup4
 requests
+chromadb
+pypdf


### PR DESCRIPTION
This commit adds the ability to process PDF files in the RAG system. It also adds `chromadb` to the `requirements.txt` file to make it a hard dependency.

The `rag_system.py` file has been updated to:
- Include `pypdf` for PDF text extraction.
- Handle `.pdf` files in the `load_and_chunk_data` function.
- Update the user prompt to include PDF as a supported file type.